### PR TITLE
fix: apply group metadata to resource routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![Statements](https://img.shields.io/badge/statements-87.21%25-yellow.svg?style=flat)
-![Branches](https://img.shields.io/badge/branches-88.63%25-yellow.svg?style=flat)
-![Functions](https://img.shields.io/badge/functions-80.55%25-yellow.svg?style=flat)
-![Lines](https://img.shields.io/badge/lines-87.21%25-yellow.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-87.16%25-yellow.svg?style=flat)
+![Branches](https://img.shields.io/badge/branches-90.52%25-brightgreen.svg?style=flat)
+![Functions](https://img.shields.io/badge/functions-81.08%25-yellow.svg?style=flat)
+![Lines](https://img.shields.io/badge/lines-87.16%25-yellow.svg?style=flat)
 
 # Girouette
 

--- a/src/router_loader.ts
+++ b/src/router_loader.ts
@@ -25,10 +25,19 @@ export class RouterLoader {
     this.#logger = logger
   }
 
-  registerGroup(name: string, metadata: GroupMetadata, callback: () => void) {
+  registerGroup(
+    name: string,
+    metadata: GroupMetadata,
+    callback: () => void,
+    options?: { inferName?: boolean }
+  ) {
     const group = this.#router.group(() => callback())
 
-    group.as(metadata.name ?? prettifyGroupName(name))
+    if (metadata.name !== undefined) {
+      group.as(metadata.name)
+    } else if (options?.inferName !== false) {
+      group.as(prettifyGroupName(name))
+    }
 
     if (metadata.prefix) {
       group.prefix(metadata.prefix)
@@ -122,9 +131,14 @@ export class RouterLoader {
 
     if (resource) {
       if (hasGroup) {
-        this.registerGroup(controllerName, group, () => {
-          this.registerResource(controllerImport, resource)
-        })
+        this.registerGroup(
+          controllerName,
+          group,
+          () => {
+            this.registerResource(controllerImport, resource)
+          },
+          { inferName: false }
+        )
       } else {
         this.registerResource(controllerImport, resource)
       }

--- a/src/router_loader.ts
+++ b/src/router_loader.ts
@@ -114,8 +114,20 @@ export class RouterLoader {
     routes: Record<string, RouteMetadata>,
     resource?: ResourceMetadata
   ) {
+    const hasGroup =
+      group.name !== undefined ||
+      group.prefix !== undefined ||
+      group.domain !== undefined ||
+      group.middlewares !== undefined
+
     if (resource) {
-      this.registerResource(controllerImport, resource)
+      if (hasGroup) {
+        this.registerGroup(controllerName, group, () => {
+          this.registerResource(controllerImport, resource)
+        })
+      } else {
+        this.registerResource(controllerImport, resource)
+      }
       return
     }
 

--- a/test/controllers/resource_group/posts_controller.ts
+++ b/test/controllers/resource_group/posts_controller.ts
@@ -1,0 +1,16 @@
+import { Group, Resource } from '../../../index.js'
+import { HttpContext } from '@adonisjs/core/http'
+
+@Group({ name: 'api.v1', prefix: '/api/v1' })
+@Resource({ name: 'posts' })
+export default class PostsController {
+  async index({}: HttpContext) {}
+
+  async store({}: HttpContext) {}
+
+  async show({}: HttpContext) {}
+
+  async update({}: HttpContext) {}
+
+  async destroy({}: HttpContext) {}
+}

--- a/test/controllers/resource_group_prefix/posts_controller.ts
+++ b/test/controllers/resource_group_prefix/posts_controller.ts
@@ -1,0 +1,16 @@
+import { Group, Resource } from '../../../index.js'
+import { HttpContext } from '@adonisjs/core/http'
+
+@Group({ prefix: '/api' })
+@Resource('posts')
+export default class PostsController {
+  async index({}: HttpContext) {}
+
+  async store({}: HttpContext) {}
+
+  async show({}: HttpContext) {}
+
+  async update({}: HttpContext) {}
+
+  async destroy({}: HttpContext) {}
+}

--- a/test/girouette_provider.spec.ts
+++ b/test/girouette_provider.spec.ts
@@ -122,6 +122,19 @@ test.group('GirouetteProvider - Resource Routes', () => {
     assert.isTrue(routes.length > 0)
     assert.isTrue(routes.every((r) => r.pattern.startsWith('/api/v1/posts')))
     assert.isTrue(routes.every((r) => r.name.startsWith('api.v1.posts.')))
+    assert.isFalse(routes.some((r) => r.name.startsWith('api.v1.posts.posts.')))
+  })
+
+  test('should combine "resource" routes with a prefix-only "group"', async ({ assert }) => {
+    const app = await createTestApp()
+
+    const routes = await setupRoutes(app, [
+      () => import('./controllers/resource_group_prefix/posts_controller.js'),
+    ])
+
+    assert.isTrue(routes.length > 0)
+    assert.isTrue(routes.every((r) => r.pattern.startsWith('/api/posts')))
+    assert.isTrue(routes.every((r) => r.name.startsWith('posts.')))
     assert.isFalse(routes.some((r) => r.name.startsWith('posts.posts.')))
   })
 

--- a/test/girouette_provider.spec.ts
+++ b/test/girouette_provider.spec.ts
@@ -104,10 +104,25 @@ test.group('GirouetteProvider - Resource Routes', () => {
 
     assert.isTrue(routes.length > 0)
     assert.isTrue(routes.every((r) => r.pattern.startsWith('/posts')))
+    assert.isTrue(routes.every((r) => r.name.startsWith('posts.')))
+    assert.isFalse(routes.some((r) => r.name.startsWith('posts.posts.')))
     assert.isTrue(routes.every((r) => r.methods.every((m) => HTTP_METHODS.includes(m))))
 
     const controllerMethods = routes.map((r) => extractMethodFromHandler(r.handler))
     assert.isTrue(controllerMethods.every((m) => RESOURCE_METHODS.includes(m.toLowerCase())))
+  })
+
+  test('should combine "resource" routes with a "group"', async ({ assert }) => {
+    const app = await createTestApp()
+
+    const routes = await setupRoutes(app, [
+      () => import('./controllers/resource_group/posts_controller.js'),
+    ])
+
+    assert.isTrue(routes.length > 0)
+    assert.isTrue(routes.every((r) => r.pattern.startsWith('/api/v1/posts')))
+    assert.isTrue(routes.every((r) => r.name.startsWith('api.v1.posts.')))
+    assert.isFalse(routes.some((r) => r.name.startsWith('posts.posts.')))
   })
 
   test('should rename "resource" params', async ({ assert }) => {


### PR DESCRIPTION
Resources were previously registered before `registerGroup` was called, causing `@Group`, `@GroupMiddleware`, and `@GroupDomain` to be ignored when combined with `@Resource`.